### PR TITLE
Develop

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2058,6 +2058,10 @@ export default Vue.extend<
     > .v-icon {
       display: none;
     }
+    .speed,
+    .orbit {
+      visibility: hidden;
+    }
   }
   .note.type94,
   .note.type95 {
@@ -2079,6 +2083,11 @@ export default Vue.extend<
     .note {
       color: transparent;
       text-shadow: none;
+
+      .speed,
+      .orbit {
+        visibility: hidden;
+      }
     }
     .note.type5 {
       box-shadow: 0 0 16px 0 gold;
@@ -2116,6 +2125,10 @@ export default Vue.extend<
         border-radius: 4px;
         width: 20px !important;
         left: -40px !important;
+      }
+      .speed,
+      .orbit {
+        visibility: hidden;
       }
     }
   }

--- a/src/components/LongNote.vue
+++ b/src/components/LongNote.vue
@@ -59,6 +59,7 @@
       </div>
     </template>
 
+    <!-- ポップアップ編集 -->
     <v-card v-if="menu" rounded="lg">
       <v-list>
         <v-list-item>
@@ -74,21 +75,17 @@
         </v-list-item>
         <v-card-text class="ml-4">始点</v-card-text>
         <v-list-item>
-          <v-row>
-            <v-col>
-              <v-text-field
-                :value="note.measure"
-                @change="value => (note.measure = Number(value))"
-                hide-details
-                suffix="小節"
-                outlined
-                dense
-              ></v-text-field>
-            </v-col>
-          </v-row>
+          <v-text-field
+            :value="note.measure"
+            @change="value => (note.measure = Number(value))"
+            hide-details
+            suffix="小節"
+            outlined
+            dense
+          ></v-text-field>
         </v-list-item>
         <v-list-item>
-          <v-row>
+          <v-row class="mb-0">
             <v-col cols="12" sm="6">
               <v-text-field
                 v-model="note.position"
@@ -125,20 +122,16 @@
           :key="`longnote_end_${note.index}_${i}`"
         >
           <v-divider></v-divider>
-          <v-card-text class="ml-4 mt-2">終点{{ i }}</v-card-text>
+          <v-card-text class="ml-4 mt-2">終点 #{{ i }}</v-card-text>
           <v-list-item>
-            <v-row>
-              <v-col>
-                <v-text-field
-                  :value="end.measure"
-                  @change="value => (end.measure = Number(value))"
-                  hide-details
-                  suffix="小節"
-                  outlined
-                  dense
-                ></v-text-field>
-              </v-col>
-            </v-row>
+            <v-text-field
+              :value="end.measure"
+              @change="value => (end.measure = Number(value))"
+              hide-details
+              suffix="小節"
+              outlined
+              dense
+            ></v-text-field>
           </v-list-item>
           <v-list-item>
             LANE
@@ -148,7 +141,7 @@
             </v-radio-group>
           </v-list-item>
           <v-list-item>
-            <v-row>
+            <v-row class="mb-0">
               <v-col cols="12" sm="6">
                 <v-text-field
                   v-model="end.position"
@@ -170,6 +163,14 @@
                 ></v-text-field>
               </v-col>
             </v-row>
+          </v-list-item>
+          <v-list-item>
+            終端
+            <v-spacer></v-spacer>
+            <v-radio-group v-model="end.type" row hide-details>
+              <v-radio label="あり" :value="1" class="ml-2"></v-radio>
+              <v-radio label="なし" :value="89" class="ml-2"></v-radio>
+            </v-radio-group>
           </v-list-item>
         </div>
 

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -106,23 +106,19 @@
         </v-list-item>
 
         <v-list-item>
-          <v-row>
-            <v-col>
-              <v-text-field
-                :value="note.measure"
-                @change="(value) => (note.measure = Number(value))"
-                @keydown.enter.stop="menu = false"
-                hide-details
-                suffix="小節"
-                outlined
-                dense
-              ></v-text-field>
-            </v-col>
-          </v-row>
+          <v-text-field
+            :value="note.measure"
+            @change="(value) => (note.measure = Number(value))"
+            @keydown.enter.stop="menu = false"
+            hide-details
+            suffix="小節"
+            outlined
+            dense
+          ></v-text-field>
         </v-list-item>
 
         <v-list-item>
-          <v-row>
+          <v-row class="mb-0">
             <v-col cols="12" sm="6">
               <v-text-field
                 v-model.number="note.position"
@@ -152,7 +148,9 @@
           <v-radio-group
             v-model.number="note.lane"
             row
+            hide-details
             :disabled="getIsLanelessNote"
+            class="mt-0"
           >
             <v-radio v-for="n in 5" :key="n" :value="n"></v-radio>
           </v-radio-group>

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -365,6 +365,10 @@ export default Vue.extend({
       else if ([3, 4].includes(this.drawType)) {
         if (this.drawOptions[3]) { return Number(this.drawOptions[3]) }
       }
+      // 上下フリック
+      else if ([6, 7].includes(this.drawType)) {
+        if (this.drawOptions[3]) { return Number(this.drawOptions[3]) }
+      }
       // テクスチャ
       else if (this.drawType === 94) {
         if (this.drawOptions[5]) { return Number(this.drawOptions[5]) }
@@ -382,6 +386,10 @@ export default Vue.extend({
       }
       // 左右フリック
       else if ([3, 4].includes(this.drawType)) {
+        if (this.drawOptions[4]) { return Number(this.drawOptions[4]) }
+      }
+      // 上下フリック
+      else if ([6, 7].includes(this.drawType)) {
         if (this.drawOptions[4]) { return Number(this.drawOptions[4]) }
       }
       // テクスチャ

--- a/src/mixins/noteCheck.ts
+++ b/src/mixins/noteCheck.ts
@@ -226,14 +226,28 @@ export default Vue.extend({
         return option;
       }
 
-      // 区切り線、拍子変化、BPM変化の場合
-      // option: [length]
+      // 区切り線の場合
+      // option: [length (, speed (, orbit))]
+      else if ([95].includes(note.type)) {
+        // position: 0 => 小節線非表示制御の時は option: ["-1"]
+        if (note.type === 95 && note.position === 0) return ["-1"];
+        // length
+        option.append(note.option[0] ? String(note.option[0]) : "1");
+        // speed
+        if (note.option[1]) {
+          option.append(String(note.option[1]));
+          // orbit
+          if (note.option[2]) {
+            option.append(String(note.option[2]));
+          }
+        }
+        return option;
+      }
+
+      // 拍子変化、BPM変化の場合
       // option: [beat]
       // option: [bpm]
-      else if ([95, 97, 98].includes(note.type)) {
-        // type95 小節線非表示制御の時は option: ["-1"]
-        if (note.type === 95 && note.position === 0) return ["-1"];
-
+      else if ([97, 98].includes(note.type)) {
         option.append(note.option[0] ? String(note.option[0]) : "-1");
         return option;
       }


### PR DESCRIPTION
This pull request primarily focuses on improving the UI and data handling for note editing in the application. The main changes enhance the visibility and editing experience for note properties, especially for long notes and special note types. Additionally, there are improvements to how certain note options are processed and displayed.

**UI/UX Improvements for Note Editing:**

* Simplified the layout of note and long note editing dialogs by removing unnecessary `v-row` and `v-col` wrappers, resulting in a cleaner and more compact form. Also added `mb-0` and `mt-0` classes to reduce spacing where appropriate. [[1]](diffhunk://#diff-e112ea1aa1f045c78dcf62f1f4042bd4e3fabdd4905cf1f06e22304523c0e489L77-L78) [[2]](diffhunk://#diff-e112ea1aa1f045c78dcf62f1f4042bd4e3fabdd4905cf1f06e22304523c0e489L87-R88) [[3]](diffhunk://#diff-e112ea1aa1f045c78dcf62f1f4042bd4e3fabdd4905cf1f06e22304523c0e489L151-R144) [[4]](diffhunk://#diff-91ca1fe05197733d3cd0064cfdf315e706907a5ad6dad09171ebcf453c0df1a2L109-L110) [[5]](diffhunk://#diff-91ca1fe05197733d3cd0064cfdf315e706907a5ad6dad09171ebcf453c0df1a2L120-R121) [[6]](diffhunk://#diff-91ca1fe05197733d3cd0064cfdf315e706907a5ad6dad09171ebcf453c0df1a2R151-R153)
* Improved the labeling and clarity of long note endpoints by changing the label from `終点{{ i }}` to `終点 #{{ i }}` and adding a radio group for selecting the endpoint type ("あり" or "なし"). [[1]](diffhunk://#diff-e112ea1aa1f045c78dcf62f1f4042bd4e3fabdd4905cf1f06e22304523c0e489L128-L131) [[2]](diffhunk://#diff-e112ea1aa1f045c78dcf62f1f4042bd4e3fabdd4905cf1f06e22304523c0e489R167-R174)
* Added Japanese comment (`<!-- ポップアップ編集 -->`) to clarify the purpose of the popup edit card in `LongNote.vue`.

**Visibility and Styling Adjustments:**

* Updated CSS to hide `.speed` and `.orbit` elements in certain contexts and ensure they are not displayed for specific note types or under specific conditions. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R2061-R2064) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R2086-R2090) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R2129-R2132)

**Logic and Data Handling for Notes:**

* Enhanced the logic for handling note options in `noteCheck.ts`, specifically splitting the processing for barlines (type 95) to support additional options (`speed`, `orbit`), while keeping beat and BPM changes (types 97, 98) handled separately. This allows for more flexible data representation for barlines.
* Added support for up/down flick note types (6, 7) in the option parsing logic in `Note.vue`, ensuring their options are correctly processed for both `drawOptions[3]` and `drawOptions[4]`. [[1]](diffhunk://#diff-91ca1fe05197733d3cd0064cfdf315e706907a5ad6dad09171ebcf453c0df1a2R368-R371) [[2]](diffhunk://#diff-91ca1fe05197733d3cd0064cfdf315e706907a5ad6dad09171ebcf453c0df1a2R391-R394)